### PR TITLE
Restrict matplotlib connextions to 1 or 2D. Fixes #15

### DIFF
--- a/display/GPI/Matplotlib_GPI.py
+++ b/display/GPI/Matplotlib_GPI.py
@@ -1015,7 +1015,7 @@ class ExternalNode(gpi.NodeAPI):
         # IO Ports
         self.inport_range = list(range(0, 8))
         for i in self.inport_range:
-            self.addInPort('in' + str(i), 'NPYarray', obligation=gpi.OPTIONAL)
+            self.addInPort('in' + str(i), 'NPYarray', drange=(1,2), obligation=gpi.OPTIONAL)
 
     def compute(self):
 


### PR DESCRIPTION
This is a pretty trivial bug fix but I want to go ahead and publish it as it's a crashing bug.